### PR TITLE
Terraform script for S3 to CloudFront invalidation

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,0 +1,73 @@
+import json
+import boto3
+import os
+import urllib.parse
+from datetime import datetime
+
+def lambda_handler(event, context):
+    """
+    Lambda function to invalidate CloudFront cache when objects are created in S3
+    """
+    
+    # Initialize CloudFront client
+    cloudfront = boto3.client('cloudfront')
+    
+    # Get CloudFront distribution ID from environment variable
+    distribution_id = os.environ['CLOUDFRONT_DISTRIBUTION_ID']
+    
+    # Parse S3 event
+    try:
+        # Extract object keys from S3 event
+        object_keys = []
+        
+        for record in event['Records']:
+            # Get the object key and decode URL encoding
+            object_key = urllib.parse.unquote_plus(record['s3']['object']['key'], encoding='utf-8')
+            object_keys.append('/' + object_key)
+            
+            print(f"Object created: {object_key}")
+        
+        if not object_keys:
+            print("No objects to invalidate")
+            return {
+                'statusCode': 200,
+                'body': json.dumps('No objects to invalidate')
+            }
+        
+        # Create invalidation
+        invalidation_batch = {
+            'Paths': {
+                'Quantity': len(object_keys),
+                'Items': object_keys
+            },
+            'CallerReference': f"lambda-invalidation-{datetime.now().isoformat()}"
+        }
+        
+        response = cloudfront.create_invalidation(
+            DistributionId=distribution_id,
+            InvalidationBatch=invalidation_batch
+        )
+        
+        invalidation_id = response['Invalidation']['Id']
+        
+        print(f"CloudFront invalidation created: {invalidation_id}")
+        print(f"Invalidated paths: {object_keys}")
+        
+        return {
+            'statusCode': 200,
+            'body': json.dumps({
+                'message': 'CloudFront invalidation created successfully',
+                'invalidation_id': invalidation_id,
+                'paths': object_keys
+            })
+        }
+        
+    except Exception as e:
+        print(f"Error creating CloudFront invalidation: {str(e)}")
+        return {
+            'statusCode': 500,
+            'body': json.dumps({
+                'error': 'Failed to create CloudFront invalidation',
+                'details': str(e)
+            })
+        }

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -7,58 +7,81 @@ from datetime import datetime
 def lambda_handler(event, context):
     """
     Lambda function to invalidate CloudFront cache when objects are created in S3
+    Supports multiple S3 buckets mapped to different CloudFront distributions
     """
     
     # Initialize CloudFront client
     cloudfront = boto3.client('cloudfront')
     
-    # Get CloudFront distribution ID from environment variable
-    distribution_id = os.environ['CLOUDFRONT_DISTRIBUTION_ID']
+    # Get bucket to distribution mapping from environment variable
+    bucket_distribution_mapping = json.loads(os.environ['BUCKET_DISTRIBUTION_MAPPING'])
     
     # Parse S3 event
     try:
-        # Extract object keys from S3 event
-        object_keys = []
+        # Group object keys by bucket
+        bucket_objects = {}
         
         for record in event['Records']:
-            # Get the object key and decode URL encoding
+            # Get bucket name and object key
+            bucket_name = record['s3']['bucket']['name']
             object_key = urllib.parse.unquote_plus(record['s3']['object']['key'], encoding='utf-8')
-            object_keys.append('/' + object_key)
             
-            print(f"Object created: {object_key}")
+            if bucket_name not in bucket_objects:
+                bucket_objects[bucket_name] = []
+            
+            bucket_objects[bucket_name].append('/' + object_key)
+            print(f"Object created in bucket {bucket_name}: {object_key}")
         
-        if not object_keys:
+        if not bucket_objects:
             print("No objects to invalidate")
             return {
                 'statusCode': 200,
                 'body': json.dumps('No objects to invalidate')
             }
         
-        # Create invalidation
-        invalidation_batch = {
-            'Paths': {
-                'Quantity': len(object_keys),
-                'Items': object_keys
-            },
-            'CallerReference': f"lambda-invalidation-{datetime.now().isoformat()}"
-        }
+        invalidation_results = []
         
-        response = cloudfront.create_invalidation(
-            DistributionId=distribution_id,
-            InvalidationBatch=invalidation_batch
-        )
-        
-        invalidation_id = response['Invalidation']['Id']
-        
-        print(f"CloudFront invalidation created: {invalidation_id}")
-        print(f"Invalidated paths: {object_keys}")
+        # Process each bucket separately
+        for bucket_name, object_keys in bucket_objects.items():
+            # Get the corresponding CloudFront distribution ID
+            if bucket_name not in bucket_distribution_mapping:
+                print(f"Warning: No CloudFront distribution mapping found for bucket {bucket_name}")
+                continue
+            
+            distribution_id = bucket_distribution_mapping[bucket_name]
+            
+            # Create invalidation for this distribution
+            invalidation_batch = {
+                'Paths': {
+                    'Quantity': len(object_keys),
+                    'Items': object_keys
+                },
+                'CallerReference': f"lambda-invalidation-{bucket_name}-{datetime.now().isoformat()}"
+            }
+            
+            response = cloudfront.create_invalidation(
+                DistributionId=distribution_id,
+                InvalidationBatch=invalidation_batch
+            )
+            
+            invalidation_id = response['Invalidation']['Id']
+            
+            print(f"CloudFront invalidation created for {bucket_name}: {invalidation_id}")
+            print(f"Distribution ID: {distribution_id}")
+            print(f"Invalidated paths: {object_keys}")
+            
+            invalidation_results.append({
+                'bucket_name': bucket_name,
+                'distribution_id': distribution_id,
+                'invalidation_id': invalidation_id,
+                'paths': object_keys
+            })
         
         return {
             'statusCode': 200,
             'body': json.dumps({
-                'message': 'CloudFront invalidation created successfully',
-                'invalidation_id': invalidation_id,
-                'paths': object_keys
+                'message': 'CloudFront invalidations created successfully',
+                'invalidations': invalidation_results
             })
         }
         

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,129 @@
+# Data sources for existing resources
+data "aws_s3_bucket" "existing_bucket" {
+  bucket = var.bucket_name
+}
+
+data "aws_cloudfront_distribution" "existing_distribution" {
+  id = var.cloudfront_distribution_id
+}
+
+# IAM role for Lambda function
+resource "aws_iam_role" "lambda_role" {
+  name = "cloudfront-invalidation-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# IAM policy for CloudFront invalidation
+resource "aws_iam_policy" "cloudfront_invalidation_policy" {
+  name        = "cloudfront-invalidation-policy"
+  description = "Policy to allow CloudFront cache invalidation"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudfront:CreateInvalidation"
+        ]
+        Resource = data.aws_cloudfront_distribution.existing_distribution.arn
+      }
+    ]
+  })
+}
+
+# IAM policy for CloudWatch logging
+resource "aws_iam_policy" "lambda_logging_policy" {
+  name        = "lambda-logging-policy"
+  description = "Policy to allow Lambda to write logs to CloudWatch"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+# Attach policies to Lambda role
+resource "aws_iam_role_policy_attachment" "lambda_cloudfront_policy" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.cloudfront_invalidation_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_logging_policy" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.lambda_logging_policy.arn
+}
+
+# Create deployment package for Lambda function
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  source_file = "lambda_function.py"
+  output_path = "lambda_function.zip"
+}
+
+# Lambda function
+resource "aws_lambda_function" "cloudfront_invalidation" {
+  filename         = "lambda_function.zip"
+  function_name    = "cloudfront-cache-invalidation"
+  role            = aws_iam_role.lambda_role.arn
+  handler         = "lambda_function.lambda_handler"
+  runtime         = "python3.9"
+  timeout         = 60
+
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+
+  environment {
+    variables = {
+      CLOUDFRONT_DISTRIBUTION_ID = var.cloudfront_distribution_id
+    }
+  }
+}
+
+# CloudWatch Log Group for Lambda
+resource "aws_cloudwatch_log_group" "lambda_logs" {
+  name              = "/aws/lambda/${aws_lambda_function.cloudfront_invalidation.function_name}"
+  retention_in_days = 14
+}
+
+# Lambda permission to allow S3 to invoke the function
+resource "aws_lambda_permission" "allow_s3" {
+  statement_id  = "AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cloudfront_invalidation.function_name
+  principal     = "s3.amazonaws.com"
+  source_arn    = data.aws_s3_bucket.existing_bucket.arn
+}
+
+# S3 bucket notification
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = data.aws_s3_bucket.existing_bucket.id
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.cloudfront_invalidation.arn
+    events              = ["s3:ObjectCreated:*"]
+  }
+
+  depends_on = [aws_lambda_permission.allow_s3]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,12 @@
 # Data sources for existing resources
-data "aws_s3_bucket" "existing_bucket" {
-  bucket = var.bucket_name
+data "aws_s3_bucket" "existing_buckets" {
+  for_each = var.bucket_distribution_mapping
+  bucket   = each.key
 }
 
-data "aws_cloudfront_distribution" "existing_distribution" {
-  id = var.cloudfront_distribution_id
+data "aws_cloudfront_distribution" "existing_distributions" {
+  for_each = var.bucket_distribution_mapping
+  id       = each.value.cloudfront_distribution_id
 }
 
 # IAM role for Lambda function
@@ -38,7 +40,9 @@ resource "aws_iam_policy" "cloudfront_invalidation_policy" {
         Action = [
           "cloudfront:CreateInvalidation"
         ]
-        Resource = data.aws_cloudfront_distribution.existing_distribution.arn
+        Resource = [
+          for dist in data.aws_cloudfront_distribution.existing_distributions : dist.arn
+        ]
       }
     ]
   })
@@ -96,7 +100,9 @@ resource "aws_lambda_function" "cloudfront_invalidation" {
 
   environment {
     variables = {
-      CLOUDFRONT_DISTRIBUTION_ID = var.cloudfront_distribution_id
+      BUCKET_DISTRIBUTION_MAPPING = jsonencode({
+        for bucket_name, config in var.bucket_distribution_mapping : bucket_name => config.cloudfront_distribution_id
+      })
     }
   }
 }
@@ -107,22 +113,28 @@ resource "aws_cloudwatch_log_group" "lambda_logs" {
   retention_in_days = 14
 }
 
-# Lambda permission to allow S3 to invoke the function
+# Lambda permissions to allow S3 buckets to invoke the function
 resource "aws_lambda_permission" "allow_s3" {
-  statement_id  = "AllowExecutionFromS3Bucket"
+  for_each      = var.bucket_distribution_mapping
+  statement_id  = "AllowExecutionFromS3Bucket-${each.key}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.cloudfront_invalidation.function_name
   principal     = "s3.amazonaws.com"
-  source_arn    = data.aws_s3_bucket.existing_bucket.arn
+  source_arn    = data.aws_s3_bucket.existing_buckets[each.key].arn
 }
 
-# S3 bucket notification
-resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = data.aws_s3_bucket.existing_bucket.id
+# S3 bucket notifications
+resource "aws_s3_bucket_notification" "bucket_notifications" {
+  for_each = var.bucket_distribution_mapping
+  bucket   = data.aws_s3_bucket.existing_buckets[each.key].id
 
   lambda_function {
     lambda_function_arn = aws_lambda_function.cloudfront_invalidation.arn
     events              = ["s3:ObjectCreated:*"]
+    
+    # Add optional prefix and suffix filters
+    filter_prefix = each.value.prefix_filter != "" ? each.value.prefix_filter : null
+    filter_suffix = each.value.suffix_filter != "" ? each.value.suffix_filter : null
   }
 
   depends_on = [aws_lambda_permission.allow_s3]

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,9 @@
+output "lambda_function_name" {
+  description = "Name of the Lambda function"
+  value       = aws_lambda_function.cloudfront_invalidation.function_name
+}
+
+output "lambda_function_arn" {
+  description = "ARN of the Lambda function"
+  value       = aws_lambda_function.cloudfront_invalidation.arn
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,19 @@ output "lambda_function_arn" {
   description = "ARN of the Lambda function"
   value       = aws_lambda_function.cloudfront_invalidation.arn
 }
+
+output "configured_buckets" {
+  description = "List of S3 buckets configured with CloudFront invalidation"
+  value       = keys(var.bucket_distribution_mapping)
+}
+
+output "bucket_distribution_mapping" {
+  description = "Complete mapping of buckets to CloudFront distributions"
+  value = {
+    for bucket_name, config in var.bucket_distribution_mapping : bucket_name => {
+      cloudfront_distribution_id = config.cloudfront_distribution_id
+      prefix_filter             = config.prefix_filter
+      suffix_filter             = config.suffix_filter
+    }
+  }
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,3 @@
+# Example values for the required variables
+bucket_name = "your-existing-s3-bucket-name"
+cloudfront_distribution_id = "E1234567890ABC"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,3 +1,29 @@
-# Example values for the required variables
-bucket_name = "your-existing-s3-bucket-name"
-cloudfront_distribution_id = "E1234567890ABC"
+# Example configuration for multiple S3 buckets and CloudFront distributions
+bucket_distribution_mapping = {
+  # Website bucket with assets prefix filter
+  "my-website-bucket" = {
+    cloudfront_distribution_id = "E1234567890ABC"
+    prefix_filter             = "assets/"  # Only invalidate files in assets/ folder
+    suffix_filter             = ""
+  }
+  
+  # API documentation bucket
+  "my-api-docs-bucket" = {
+    cloudfront_distribution_id = "E0987654321XYZ"
+    prefix_filter             = ""
+    suffix_filter             = ".html"     # Only invalidate HTML files
+  }
+  
+  # Static content bucket without filters
+  "my-static-content-bucket" = {
+    cloudfront_distribution_id = "E5555666677ABC"
+    # No filters - invalidate all objects
+  }
+  
+  # Media bucket with specific folder
+  "my-media-bucket" = {
+    cloudfront_distribution_id = "E1111222233DEF"
+    prefix_filter             = "public/"
+    suffix_filter             = ""
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,20 @@
-variable "bucket_name" {
-  description = "Name of the existing S3 bucket"
-  type        = string
-}
-
-variable "cloudfront_distribution_id" {
-  description = "ID of the existing CloudFront distribution"
-  type        = string
+variable "bucket_distribution_mapping" {
+  description = "Map of S3 bucket names to their corresponding CloudFront distribution IDs"
+  type = map(object({
+    cloudfront_distribution_id = string
+    prefix_filter             = optional(string, "")  # Optional: filter S3 events by object key prefix
+    suffix_filter             = optional(string, "")  # Optional: filter S3 events by object key suffix
+  }))
+  
+  # Example:
+  # bucket_distribution_mapping = {
+  #   "my-website-bucket" = {
+  #     cloudfront_distribution_id = "E1234567890ABC"
+  #     prefix_filter             = "assets/"
+  #     suffix_filter             = ""
+  #   }
+  #   "my-api-bucket" = {
+  #     cloudfront_distribution_id = "E0987654321XYZ"
+  #   }
+  # }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  description = "Name of the existing S3 bucket"
+  type        = string
+}
+
+variable "cloudfront_distribution_id" {
+  description = "ID of the existing CloudFront distribution"
+  type        = string
+}


### PR DESCRIPTION
Add Terraform configuration to deploy a Lambda function that invalidates CloudFront cache on S3 object creation.

---
<a href="https://cursor.com/background-agent?bcId=bc-0541eac7-9080-4f52-80f3-136fa2239710">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0541eac7-9080-4f52-80f3-136fa2239710">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>