### PR TITLE
Terraform script for CloudFront cache invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# CloudFront Invalidation Lambda Function
+
+This Terraform configuration sets up a Lambda function that automatically invalidates CloudFront cache when objects are created in an S3 bucket.
+
+## Components
+
+- **Lambda Function**: Node.js function that creates CloudFront invalidations
+- **S3 Event Notification**: Triggers Lambda when objects are created in the bucket
+- **IAM Role & Policies**: Permissions for CloudFront invalidation and CloudWatch logging
+- **Lambda Permission**: Allows S3 to invoke the Lambda function
+
+## Prerequisites
+
+- Existing S3 bucket
+- Existing CloudFront distribution
+- Terraform installed and configured with AWS credentials
+
+## Usage
+
+1. **Install dependencies and create Lambda package**:
+   ```bash
+   npm install
+   npm run zip
+   ```
+
+2. **Set your variables**:
+   ```bash
+   cp terraform.tfvars.example terraform.tfvars
+   # Edit terraform.tfvars with your actual values
+   ```
+
+3. **Initialize and apply Terraform**:
+   ```bash
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+## Variables
+
+- `bucket_name`: Name of the existing S3 bucket
+- `cloudfront_distribution_id`: ID of the existing CloudFront distribution
+
+## Outputs
+
+- `lambda_function_name`: Name of the created Lambda function
+
+## How it works
+
+1. When an object is created in the S3 bucket, it triggers an S3 event notification
+2. The event notification invokes the Lambda function
+3. The Lambda function creates a CloudFront invalidation for the specific object path
+4. CloudFront cache is invalidated and the new content is served on subsequent requests

--- a/lambda_function.js
+++ b/lambda_function.js
@@ -1,0 +1,53 @@
+const AWS = require('aws-sdk');
+
+const cloudfront = new AWS.CloudFront();
+
+exports.handler = async (event) => {
+    console.log('Event:', JSON.stringify(event, null, 2));
+    
+    try {
+        // Get the CloudFront distribution ID from environment variables
+        const distributionId = process.env.CLOUDFRONT_DISTRIBUTION_ID;
+        
+        if (!distributionId) {
+            throw new Error('CLOUDFRONT_DISTRIBUTION_ID environment variable is not set');
+        }
+        
+        // Process each S3 event record
+        for (const record of event.Records) {
+            const bucketName = record.s3.bucket.name;
+            const objectKey = decodeURIComponent(record.s3.object.key.replace(/\+/g, ' '));
+            
+            console.log(`Processing object: ${objectKey} from bucket: ${bucketName}`);
+            
+            // Create CloudFront invalidation
+            const invalidationParams = {
+                DistributionId: distributionId,
+                InvalidationBatch: {
+                    CallerReference: `s3-invalidation-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+                    Paths: {
+                        Quantity: 1,
+                        Items: [`/${objectKey}`]
+                    }
+                }
+            };
+            
+            console.log('Creating CloudFront invalidation with params:', JSON.stringify(invalidationParams, null, 2));
+            
+            const result = await cloudfront.createInvalidation(invalidationParams).promise();
+            
+            console.log('CloudFront invalidation created successfully:', JSON.stringify(result, null, 2));
+        }
+        
+        return {
+            statusCode: 200,
+            body: JSON.stringify({
+                message: 'CloudFront invalidation completed successfully'
+            })
+        };
+        
+    } catch (error) {
+        console.error('Error creating CloudFront invalidation:', error);
+        throw error;
+    }
+};

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "lambda_function_name" {
+  description = "Name of the CloudFront invalidation Lambda function"
+  value       = aws_lambda_function.cloudfront_invalidation.function_name
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cloudfront-invalidation-lambda",
+  "version": "1.0.0",
+  "description": "Lambda function to invalidate CloudFront cache on S3 object creation",
+  "main": "index.js",
+  "dependencies": {
+    "aws-sdk": "^2.1450.0"
+  },
+  "scripts": {
+    "zip": "zip -r lambda_function.zip . -x '*.git*' '*.terraform*' '*.tf*' 'README.md' 'package-lock.json'"
+  }
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,3 @@
+# Example values - replace with your actual values
+bucket_name = "your-s3-bucket-name"
+cloudfront_distribution_id = "E1234567890ABCD"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  description = "Name of the existing S3 bucket"
+  type        = string
+}
+
+variable "cloudfront_distribution_id" {
+  description = "ID of the existing CloudFront distribution"
+  type        = string
+}


### PR DESCRIPTION
Add a Terraform script to deploy a Lambda function that automatically invalidates CloudFront cache upon S3 object creation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7c37cb1-734a-4806-b414-caac2180385e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7c37cb1-734a-4806-b414-caac2180385e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>